### PR TITLE
fix the date deserialization

### DIFF
--- a/src/main/java/cz/smarteon/loxone/Codec.java
+++ b/src/main/java/cz/smarteon/loxone/Codec.java
@@ -11,12 +11,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.Formatter;
 import java.util.List;
+import java.util.Locale;
 
 import static com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS;
 import static com.fasterxml.jackson.databind.MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES;
@@ -25,9 +28,15 @@ import static cz.smarteon.loxone.message.MessageHeader.PAYLOAD_LENGTH;
 
 public abstract class Codec {
 
+    private static String DATE_PATTERN = "yyyy-MM-dd hh:mm:ss";
+
+    public static DateFormat DATE_FORMAT = new SimpleDateFormat(DATE_PATTERN);
+
     private static ObjectMapper MAPPER = new ObjectMapper()
             .configure(ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
-            .configure(ALLOW_UNQUOTED_CONTROL_CHARS, true);
+            .configure(ALLOW_UNQUOTED_CONTROL_CHARS, true)
+            .setDateFormat(DATE_FORMAT)
+            .setLocale(Locale.getDefault());
 
     private static final char SEPARATOR = ':';
 
@@ -71,6 +80,10 @@ public abstract class Codec {
         }
 
         return sb.toString();
+    }
+
+    public static String writeMessage(final Object message) throws IOException {
+        return MAPPER.writeValueAsString(message);
     }
 
     public static LoxoneMessage readMessage(final String message) throws IOException {

--- a/src/main/java/cz/smarteon/loxone/config/LoxoneConfig.java
+++ b/src/main/java/cz/smarteon/loxone/config/LoxoneConfig.java
@@ -23,9 +23,7 @@ public class LoxoneConfig implements Serializable {
     private final Map<LoxoneUuid, Control> controls;
 
     @JsonCreator
-    public LoxoneConfig(@JsonProperty("lastModified")
-                            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd hh:mm:ss")
-                                    Date lastModified,
+    public LoxoneConfig(@JsonProperty("lastModified") Date lastModified,
                         @JsonProperty("controls") Map<LoxoneUuid, Control> controls) {
         this.lastModified = lastModified;
         this.controls = controls;

--- a/src/main/java/cz/smarteon/loxone/message/DateValue.java
+++ b/src/main/java/cz/smarteon/loxone/message/DateValue.java
@@ -1,7 +1,6 @@
 package cz.smarteon.loxone.message;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.util.Date;
 
@@ -14,7 +13,6 @@ public class DateValue implements LoxoneValue {
     }
 
     @JsonCreator
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd hh:mm:ss")
     public static DateValue create(Date date) {
         return new DateValue(date);
     }

--- a/src/test/groovy/cz/smarteon/loxone/LoxoneUuidTest.groovy
+++ b/src/test/groovy/cz/smarteon/loxone/LoxoneUuidTest.groovy
@@ -13,12 +13,12 @@ class LoxoneUuidTest extends Specification implements SerializationSupport {
 
     def "should serialize"() {
         expect:
-        MAPPER.writeValueAsString(testUuid) == "\"$testUuidString\""
+        writeValue(testUuid) == "\"$testUuidString\""
     }
 
     def "should deserialize"() {
         expect:
-        MAPPER.readValue("\"$testUuidString\"", LoxoneUuid) == testUuid
+        readValue("\"$testUuidString\"", LoxoneUuid) == testUuid
     }
 
     def "should have toString"() {

--- a/src/test/groovy/cz/smarteon/loxone/MockWebSocketServer.groovy
+++ b/src/test/groovy/cz/smarteon/loxone/MockWebSocketServer.groovy
@@ -111,7 +111,7 @@ class MockWebSocketServer extends WebSocketServer implements SerializationSuppor
         }
 
         if (message == "jdev/sys/getkey2/$USER") {
-            broadcast(MAPPER.writeValueAsString(USER_KEY))
+            broadcast(writeValue(USER_KEY))
             return
         }
 
@@ -147,7 +147,7 @@ class MockWebSocketServer extends WebSocketServer implements SerializationSuppor
         }
 
         if (message == "jdev/sys/getvisusalt/$USER") {
-            broadcast(MAPPER.writeValueAsString(USER_VISUSALT))
+            broadcast(writeValue(USER_VISUSALT))
             return
         }
 
@@ -193,7 +193,7 @@ class MockWebSocketServer extends WebSocketServer implements SerializationSuppor
     }
 
     private void broadcast(String control, int code, LoxoneValue val) {
-        broadcast(MAPPER.writeValueAsString(new LoxoneMessage(control, code, val)))
+        broadcast(writeValue(new LoxoneMessage(control, code, val)))
     }
 
     // stubbing methods an stuff vvvvvvvvvvvv

--- a/src/test/groovy/cz/smarteon/loxone/config/LoxoneConfigTest.groovy
+++ b/src/test/groovy/cz/smarteon/loxone/config/LoxoneConfigTest.groovy
@@ -6,7 +6,7 @@ import spock.lang.Specification
 
 class LoxoneConfigTest extends Specification implements SerializationSupport {
 
-    private static final Date LAST_MODIFIED = new Date(117, 10, 22, 19, 41, 1)
+    private static final Date LAST_MODIFIED = parseDate('2017-11-22 18:41:01')
     private static final LoxoneUuid UUID = new LoxoneUuid('0f869a64-0200-0a9b-ffffd4c75dbaf53c')
 
     def "should deserialize"() {

--- a/src/test/groovy/cz/smarteon/loxone/message/DateValueTest.groovy
+++ b/src/test/groovy/cz/smarteon/loxone/message/DateValueTest.groovy
@@ -2,14 +2,16 @@ package cz.smarteon.loxone.message
 
 import spock.lang.Specification
 
-
 class DateValueTest extends Specification implements SerializationSupport {
 
     def "should deserialize"() {
+        given:
+        def date = getDate()
+
         when:
-        DateValue dateValue = MAPPER.readValue('"2017-11-22 18:41:01"', DateValue)
+        DateValue dateValue = readValue("\"${formatDate(date)}\"", DateValue)
 
         then:
-        dateValue.date == new Date(117, 10, 22, 19, 41, 1)
+        dateValue.date == date
     }
 }

--- a/src/test/groovy/cz/smarteon/loxone/message/JsonValueTest.groovy
+++ b/src/test/groovy/cz/smarteon/loxone/message/JsonValueTest.groovy
@@ -7,7 +7,7 @@ class JsonValueTest extends Specification implements SerializationSupport {
 
     def "should deserialize"() {
         expect:
-        MAPPER.readValue(json, JsonValue)
+        readValue(json, JsonValue)
 
         where:
         json << ['""', '123', '{}', '[null, -6]', '{"a":null,"b":34.5}']
@@ -15,6 +15,6 @@ class JsonValueTest extends Specification implements SerializationSupport {
 
     def "should serialize"() {
         expect:
-        MAPPER.writeValueAsString(new JsonValue(new TextNode('haha'))) == '"haha"'
+        writeValue(new JsonValue(new TextNode('haha'))) == '"haha"'
     }
 }

--- a/src/test/groovy/cz/smarteon/loxone/message/PubKeyInfoTest.groovy
+++ b/src/test/groovy/cz/smarteon/loxone/message/PubKeyInfoTest.groovy
@@ -10,11 +10,11 @@ class PubKeyInfoTest extends Specification implements SerializationSupport {
 
     def "should deserialize"() {
         expect:
-        MAPPER.readValue(PUB_KEY_JSON, PubKeyInfo).pubKey == PUB_KEY_STRING.decodeBase64()
+        readValue(PUB_KEY_JSON, PubKeyInfo).pubKey == PUB_KEY_STRING.decodeBase64()
     }
 
     def "should serialize"() {
         expect:
-        MAPPER.writeValueAsString(new PubKeyInfo(PUB_KEY_STRING.decodeBase64())) == PUB_KEY_JSON
+        writeValue(new PubKeyInfo(PUB_KEY_STRING.decodeBase64())) == PUB_KEY_JSON
     }
 }

--- a/src/test/groovy/cz/smarteon/loxone/message/SerializationSupport.groovy
+++ b/src/test/groovy/cz/smarteon/loxone/message/SerializationSupport.groovy
@@ -1,13 +1,32 @@
 package cz.smarteon.loxone.message
 
-import com.fasterxml.jackson.databind.ObjectMapper
-
-import static com.fasterxml.jackson.databind.MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES
+import cz.smarteon.loxone.Codec
 
 trait SerializationSupport {
-    static ObjectMapper MAPPER = new ObjectMapper().configure(ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
 
     static <T> T readResource(String path, Class<T> type) {
-        return MAPPER.readValue(getClass().getResourceAsStream(path), type)
+        return Codec.readMessage(getClass().getResourceAsStream(path), type)
+    }
+
+    static <T> T readValue(String value, Class<T> type) {
+        return Codec.readMessage(value, type)
+    }
+
+    static String writeValue(def value) {
+        return Codec.writeMessage(value)
+    }
+
+    static Date getDate() {
+        def cal = Calendar.getInstance()
+        cal.set(Calendar.MILLISECOND, 0)
+        return cal.getTime()
+    }
+
+    static String formatDate(Date date) {
+        return Codec.DATE_FORMAT.format(date)
+    }
+
+    static Date parseDate(String date) {
+        return Codec.DATE_FORMAT.parse(date)
     }
 }


### PR DESCRIPTION
* serialization test support uses the ordinary (production) Codec
* dateformat config is global, rather than per field
* the locale and date format is hardcoded - should be fetched from
miniserver in the future

Resolves #6