### PR TITLE
Convenient cast of JsonValue to other values

### DIFF
--- a/src/main/java/cz/smarteon/loxone/Codec.java
+++ b/src/main/java/cz/smarteon/loxone/Codec.java
@@ -1,5 +1,6 @@
 package cz.smarteon.loxone;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import cz.smarteon.loxone.message.LoxoneMessage;
@@ -7,6 +8,7 @@ import cz.smarteon.loxone.message.MessageHeader;
 import cz.smarteon.loxone.message.MessageKind;
 import cz.smarteon.loxone.message.TextEvent;
 import cz.smarteon.loxone.message.ValueEvent;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -107,6 +109,18 @@ public abstract class Codec {
 
     public static <T> T readXml(final InputStream xml, final Class<T> clazz) throws IOException {
         return XML.readValue(xml, clazz);
+    }
+
+    /**
+     * Converts the given json node to the type of given class.
+     * @throws IllegalArgumentException in case the node is not convertible.
+     * @param jsonNode to convert
+     * @param clazz type class
+     * @param <T> type
+     * @return converted object
+     */
+    public static <T> T convertValue(final @NotNull JsonNode jsonNode, final @NotNull Class<T> clazz) {
+        return MAPPER.convertValue(jsonNode, clazz);
     }
 
     public static MessageHeader readHeader(final ByteBuffer bytes) {

--- a/src/main/java/cz/smarteon/loxone/message/JsonValue.java
+++ b/src/main/java/cz/smarteon/loxone/message/JsonValue.java
@@ -7,9 +7,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import cz.smarteon.loxone.Codec;
+import cz.smarteon.loxone.LoxoneException;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 
+/**
+ * Default type of {@link LoxoneValue} used in cases when {@link LoxoneMessage#getControl()} can't be used to determine
+ * more specific type. It's basically wrapper for {@link JsonNode}.
+ */
 @JsonSerialize(using = JsonValue.Serializer.class)
 public class JsonValue implements LoxoneValue {
 
@@ -23,6 +30,23 @@ public class JsonValue implements LoxoneValue {
     @JsonIgnore
     public JsonNode getJsonNode() {
         return jsonNode;
+    }
+
+    /**
+     * Tries to convert this value to more specific {@link LoxoneValue}.
+     * @throws LoxoneException in case of conversion failure.
+     * @see Codec#convertValue(JsonNode, Class)
+     * @param type type to convert to
+     * @param <V> returned type
+     * @return converted value
+     */
+    @NotNull
+    public <V extends LoxoneValue> V as(final @NotNull Class<V> type) {
+        try {
+            return Codec.convertValue(jsonNode, type);
+        } catch (IllegalArgumentException e) {
+            throw new LoxoneException("Can't convert value to type " + type, e);
+        }
     }
 
     public static class Serializer extends JsonSerializer<JsonValue> {

--- a/src/test/groovy/cz/smarteon/loxone/CodecTest.groovy
+++ b/src/test/groovy/cz/smarteon/loxone/CodecTest.groovy
@@ -1,5 +1,6 @@
 package cz.smarteon.loxone
 
+import com.fasterxml.jackson.databind.node.TextNode
 import cz.smarteon.loxone.message.MessageKind
 import cz.smarteon.loxone.message.ValueEvent
 import spock.lang.Specification
@@ -66,5 +67,10 @@ class CodecTest extends Specification {
 
         events[1].text == '[]'
         events[2].text == ''
+    }
+
+    def "should convertValue"() {
+        expect:
+        Codec.convertValue(TextNode.valueOf('textVal'), String) == 'textVal'
     }
 }

--- a/src/test/groovy/cz/smarteon/loxone/message/JsonValueTest.groovy
+++ b/src/test/groovy/cz/smarteon/loxone/message/JsonValueTest.groovy
@@ -1,6 +1,7 @@
 package cz.smarteon.loxone.message
 
 import com.fasterxml.jackson.databind.node.TextNode
+import cz.smarteon.loxone.LoxoneException
 import spock.lang.Specification
 
 class JsonValueTest extends Specification implements SerializationSupport {
@@ -16,5 +17,23 @@ class JsonValueTest extends Specification implements SerializationSupport {
     def "should serialize"() {
         expect:
         writeValue(new JsonValue(new TextNode('haha'))) == '"haha"'
+    }
+
+    def "should convert to primitives"() {
+        expect:
+        readValue(json, JsonValue).as(type)
+
+        where:
+        json          | type
+        '"20"'        | IntValue
+        '"220283340"' | LongValue
+    }
+
+    def "should not convert incompatible"() {
+        when:
+        new JsonValue(TextNode.valueOf('notInt')).as(IntValue)
+
+        then:
+        thrown(LoxoneException)
     }
 }


### PR DESCRIPTION
This is useful for cases the message command response's value can't be recognized from the message id (mostly control messages)