### PR TITLE
Call WebSocketListener asynchronously

### DIFF
--- a/src/main/java/cz/smarteon/loxone/LoxoneWebSocket.java
+++ b/src/main/java/cz/smarteon/loxone/LoxoneWebSocket.java
@@ -66,7 +66,7 @@ public class LoxoneWebSocket {
     private int retries = 5;
 
     private boolean autoRestart = false;
-    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
     private ScheduledFuture autoRestartFuture;
 
     public LoxoneWebSocket(final @NotNull LoxoneEndpoint endpoint, final @NotNull LoxoneAuth loxoneAuth) {
@@ -373,11 +373,13 @@ public class LoxoneWebSocket {
             autoRestartFuture.cancel(true);
             autoRestartFuture = null;
         }
-        loxoneAuth.startAuthentication();
+        scheduler.execute(() -> {
+            loxoneAuth.startAuthentication();
+            if (webSocketListener != null) {
+                webSocketListener.webSocketOpened();
+            }
+        });
 
-        if (webSocketListener != null) {
-            webSocketListener.webSocketOpened();
-        }
     }
 
     void autoRestart() {

--- a/src/test/groovy/cz/smarteon/loxone/LoxoneWebSocketTest.groovy
+++ b/src/test/groovy/cz/smarteon/loxone/LoxoneWebSocketTest.groovy
@@ -85,6 +85,7 @@ class LoxoneWebSocketTest extends Specification {
         when:
         loxoneWebSocket.setWebSocketListener(listener)
         loxoneWebSocket.connectionOpened()
+        sleep(10) // wait for another thread execution
 
         then:
         loxoneWebSocket.getWebSocketListener() == listener


### PR DESCRIPTION
Synchronous call could lead to deadlock in case the listener was also using websocket (ie to send something). Resolves #73