### PR TITLE
Close the websocket scheduler properly

### DIFF
--- a/src/main/java/cz/smarteon/loxone/Loxone.java
+++ b/src/main/java/cz/smarteon/loxone/Loxone.java
@@ -185,6 +185,8 @@ public class Loxone {
 
     /**
      * Stops the service closing underlying resources, namely {@link LoxoneWebSocket}.
+     *
+     * @throws LoxoneException in case the proper close failed
      */
     public void stop() {
         loxoneWebSocket.close();

--- a/src/main/java/cz/smarteon/loxone/LoxoneAuth.java
+++ b/src/main/java/cz/smarteon/loxone/LoxoneAuth.java
@@ -19,7 +19,6 @@ import java.security.SecureRandom;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -303,12 +302,12 @@ public class LoxoneAuth implements CommandResponseListener<LoxoneMessage<?>> {
             if (autoRefreshToken) {
                 final long secondsToRefresh = new TokenState(token).secondsToRefresh();
                 if (secondsToRefresh > 0) {
-                    log.info("Scheduling token auto refresh in " + secondsToRefresh + " seconds");
-                    if (autoRefreshScheduler == null) {
-                        log.warn("autoRefreshScheduler not set, creating new one");
-                        autoRefreshScheduler = Executors.newSingleThreadScheduledExecutor();
+                    if (autoRefreshScheduler != null) {
+                        log.info("Scheduling token auto refresh in " + secondsToRefresh + " seconds");
+                        autoRefreshFuture = autoRefreshScheduler.schedule(this::startAuthentication, secondsToRefresh, TimeUnit.SECONDS);
+                    } else {
+                        log.warn("autoRefreshScheduler not set, can't schedule token refresh");
                     }
-                    autoRefreshFuture = autoRefreshScheduler.schedule(this::startAuthentication, secondsToRefresh, TimeUnit.SECONDS);
                 } else {
                     log.warn("Can't schedule token auto refresh, token expires too early or is already expired");
                 }

--- a/src/main/java/cz/smarteon/loxone/LoxoneWebSocket.java
+++ b/src/main/java/cz/smarteon/loxone/LoxoneWebSocket.java
@@ -120,13 +120,8 @@ public class LoxoneWebSocket {
     }
 
     public void close() {
-        try {
-            if (webSocketClient != null) {
-                webSocketClient.closeBlocking();
-            }
-        } catch (InterruptedException e) {
-            throw new LoxoneException("Interrupted while closing websocket", e);
-        }
+        scheduler.shutdownNow();
+        closeWebSocket();
     }
 
     @NotNull
@@ -241,7 +236,7 @@ public class LoxoneWebSocket {
                 log.trace("Waiting for authentication has been successful");
             } else {
                 if (close) {
-                    close();
+                    closeWebSocket();
                 }
                 throw new LoxoneConnectionException("Unable to authenticate within timeout");
             }
@@ -387,6 +382,16 @@ public class LoxoneWebSocket {
             final int rateSeconds = (retries + 1) * authTimeoutSeconds + 1;
             log.info("Scheduling automatic web socket restart in " + rateSeconds + " seconds");
             autoRestartFuture = scheduler.scheduleAtFixedRate(this::ensureConnection, rateSeconds, rateSeconds, TimeUnit.SECONDS);
+        }
+    }
+
+    void closeWebSocket() {
+        try {
+            if (webSocketClient != null) {
+                webSocketClient.closeBlocking();
+            }
+        } catch (InterruptedException e) {
+            throw new LoxoneException("Interrupted while closing websocket", e);
         }
     }
 

--- a/src/main/java/cz/smarteon/loxone/LoxoneWebsocketClient.java
+++ b/src/main/java/cz/smarteon/loxone/LoxoneWebsocketClient.java
@@ -10,8 +10,6 @@ import org.slf4j.LoggerFactory;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -57,7 +55,7 @@ class LoxoneWebsocketClient extends WebSocketClient {
             try {
                 if (!keepAliveLatch.await(KEEP_ALIVE_RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                     log.info("Keepalive response not received within timeout, closing connection");
-                    LoxoneWebsocketClient.this.ws.close();
+                    LoxoneWebsocketClient.this.ws.closeWebSocket();
                 }
             } catch (InterruptedException e) {
                 log.debug("Keepalive latch has been interrupted");

--- a/src/test/groovy/cz/smarteon/loxone/LoxoneAuthTest.groovy
+++ b/src/test/groovy/cz/smarteon/loxone/LoxoneAuthTest.groovy
@@ -13,6 +13,8 @@ import spock.lang.Subject
 import spock.lang.Timeout
 
 import java.security.Security
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
 
 import static cz.smarteon.loxone.CommandResponseListener.State.CONSUMED
 import static cz.smarteon.loxone.CryptoSupport.HASHING
@@ -31,6 +33,7 @@ class LoxoneAuthTest extends Specification {
     @Subject private LoxoneAuth loxoneAuth
     private LoxoneHttp http
     private CommandSender senderMock
+    private ScheduledExecutorService scheduler
 
     void setupSpec() {
         Security.addProvider(new BouncyCastleProvider())
@@ -46,7 +49,14 @@ class LoxoneAuthTest extends Specification {
         senderMock = Mock(CommandSender)
         loxoneAuth.commandSender = senderMock
 
+        scheduler = Executors.newSingleThreadScheduledExecutor()
+        loxoneAuth.setAutoRefreshScheduler(scheduler)
+
         loxoneAuth.init()
+    }
+
+    void cleanup() {
+        scheduler.shutdownNow()
     }
 
     @Timeout(2)


### PR DESCRIPTION
Also removes the auto creation of scheduler in LoxoneAuth since it was useful for tests only.

Resolves #80