### PR TITLE
Make the LoxoneWebSocketIT more reliable

### DIFF
--- a/src/main/java/cz/smarteon/loxone/LoxoneWebSocket.java
+++ b/src/main/java/cz/smarteon/loxone/LoxoneWebSocket.java
@@ -305,6 +305,8 @@ public class LoxoneWebSocket {
     }
 
 
+    // TODO Contains potential race condition when response to the sent command is received faster than command is added to queue
+    // however, the probability it happens with real miniserver is very low
     void sendInternal(final Command command) {
         log.debug("Sending websocket message: " + command.getCommand());
         webSocketClient.send(command.getCommand());

--- a/src/test/groovy/cz/smarteon/loxone/MockWebSocketServer.groovy
+++ b/src/test/groovy/cz/smarteon/loxone/MockWebSocketServer.groovy
@@ -33,12 +33,14 @@ class MockWebSocketServer extends WebSocketServer implements SerializationSuppor
 
     private final MockWebSocketServerListener listener
     private final Stubbing stubbing
+    private final int processingDelayMs
 
 
-    MockWebSocketServer(MockWebSocketServerListener listener) {
+    MockWebSocketServer(MockWebSocketServerListener listener, int processingDelayMs) {
         super(new InetSocketAddress(0))
         this.listener = listener
         stubbing = new Stubbing()
+        this.processingDelayMs = processingDelayMs
     }
 
     MockWebSocketServer(MockWebSocketServer toCopy) {
@@ -59,6 +61,7 @@ class MockWebSocketServer extends WebSocketServer implements SerializationSuppor
 
     @Override
     void onMessage(final WebSocket conn, final String message) {
+        sleep(processingDelayMs) // simulates the real miniserver processing delay
         def exchange = message =~ /jdev\/sys\/keyexchange\/(.*)/
         if (exchange.find()) {
             def sharedKeyEnc = exchange.group(1).decodeBase64()
@@ -167,8 +170,7 @@ class MockWebSocketServer extends WebSocketServer implements SerializationSuppor
         return stubbing.expect(req)
     }
 
-    void verifyExpectations(int sleep) {
-        Thread.sleep(sleep)
+    void verifyExpectations() {
         stubbing.messages.each {
             def desc = new StringDescription()
             it.request.describeTo(desc)


### PR DESCRIPTION
by adding processing delay to MockWebSocketServer the test is closer to real miniserver behaviour. However the race condition is still there.

Resolves #83