### PR TITLE
Clear the command queue on websocket close

### DIFF
--- a/src/main/java/cz/smarteon/loxone/LoxoneWebSocket.java
+++ b/src/main/java/cz/smarteon/loxone/LoxoneWebSocket.java
@@ -50,7 +50,7 @@ public class LoxoneWebSocket {
     private final BiFunction<LoxoneWebSocket, URI, WebSocketClient> webSocketClientProvider;
     private WebSocketClient webSocketClient;
     private final LoxoneEndpoint endpoint;
-    final LoxoneAuth loxoneAuth;
+    private final LoxoneAuth loxoneAuth;
 
     private LoxoneWebSocketListener webSocketListener;
     private final List<CommandResponseListener> commandResponseListeners;
@@ -393,6 +393,11 @@ public class LoxoneWebSocket {
         } catch (InterruptedException e) {
             throw new LoxoneException("Interrupted while closing websocket", e);
         }
+    }
+
+    void wsClosed() {
+        commands.clear();
+        loxoneAuth.wsClosed();
     }
 
     private boolean checkLoxoneMessage(final Command command, final LoxoneMessage loxoneMessage) {

--- a/src/main/java/cz/smarteon/loxone/LoxoneWebsocketClient.java
+++ b/src/main/java/cz/smarteon/loxone/LoxoneWebsocketClient.java
@@ -123,7 +123,7 @@ class LoxoneWebsocketClient extends WebSocketClient {
     @Override
     public void onClose(int code, String reason, boolean remote) {
         log.info("Closed by " + (remote ? "remote" : "local") + " end because of " + code +": " + reason);
-        ws.loxoneAuth.wsClosed();
+        ws.wsClosed();
         if (keepAliveFuture != null) {
             keepAliveFuture.cancel(true);
         }


### PR DESCRIPTION
When the websocket connection is lost, miniserver never sends remaining command answers to new connection

Resolves #81