### PR TITLE
Avoid race condition for authentication caused by auto refresh token

### DIFF
--- a/src/main/java/cz/smarteon/loxone/AuthListener.java
+++ b/src/main/java/cz/smarteon/loxone/AuthListener.java
@@ -6,10 +6,20 @@ package cz.smarteon.loxone;
 public interface AuthListener {
 
     /**
+     * Event triggered, just before the authentication mechanisms is started.
+     */
+    void beforeAuth();
+
+    /**
      * Event triggered when authentication is completed and underlying websocket connection can be used send authorized
      * commands.
      */
     void authCompleted();
+
+    /**
+     * Event triggered, just before the visualization authentication mechanisms is started.
+     */
+    void beforeVisuAuth();
 
     /**
      * Event triggered when visualization authentication is completed and {@link LoxoneAuth} is ready to send secured command.

--- a/src/main/java/cz/smarteon/loxone/LoxoneAuth.java
+++ b/src/main/java/cz/smarteon/loxone/LoxoneAuth.java
@@ -258,11 +258,13 @@ public class LoxoneAuth implements CommandResponseListener<LoxoneMessage<?>> {
      * Starts the authentication mechanism.
      */
     void startAuthentication() {
+        authListeners.forEach(AuthListener::beforeAuth);
         sendCommand(keyExchange(getSessionKey())); // TODO is necessary to recreate the session key everytime?
         sendCommand(getKeyCommand);
     }
 
     void startVisuAuthentication() {
+        authListeners.forEach(AuthListener::beforeVisuAuth);
         onVisuPassSet("start visual authentication", () -> {
             sendCommand(getVisuHashCommand);
             return null;


### PR DESCRIPTION
* the call of startAuthentication from scheduled refresh token wasn't guarded, which caused race condition in time of coming expiration
* adding the beforeAuth() to listener ensures all authentication
 is guarded by latch properly
* for consistency the same mechanism added to visuLatch