### PR TITLE
fix(websocket): auto-restart after abnormal local close (pong timeout)

### DIFF
--- a/src/main/java/cz/smarteon/loxone/LoxoneWebsocketClient.java
+++ b/src/main/java/cz/smarteon/loxone/LoxoneWebsocketClient.java
@@ -133,7 +133,11 @@ class LoxoneWebsocketClient extends WebSocketClient {
                 keepAliveFuture.cancel(true);
             }
             ws.connectionClosed(code, remote);
-            if (remote && code != CloseFrame.NEVER_CONNECTED) {
+            // Reconnect not only on remote close, but also on an abnormal *local* close (code 1006),
+            // which is how Java-WebSocket reports a lost connection (e.g. the miniserver stops
+            // answering pings/pongs). A deliberate LoxoneWebSocket.close() produces a NORMAL (1000)
+            // local close, so it is intentionally excluded and won't trigger a restart.
+            if (code != CloseFrame.NEVER_CONNECTED && (remote || code == CloseFrame.ABNORMAL_CLOSE)) {
                 ws.autoRestart();
             }
         }

--- a/src/test/kotlin/LoxoneWebsocketClientTest.kt
+++ b/src/test/kotlin/LoxoneWebsocketClientTest.kt
@@ -1,10 +1,10 @@
 package cz.smarteon.loxone
 
 import io.mockk.mockk
+import io.mockk.verify
+import org.java_websocket.framing.CloseFrame
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
 import strikt.api.expectCatching
 import strikt.assertions.isSuccess
 import java.net.URI
@@ -27,13 +27,27 @@ class LoxoneWebsocketClientTest {
         }.isSuccess()
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = [true, false])
-    fun `should handle onClose`(remote: Boolean) {
-        client.onClose(1000, "some reason", remote)
+    @Test
+    fun `should auto-restart on remote close`() {
+        client.onClose(CloseFrame.NORMAL, "normally closed", true)
 
-        expectCatching { webSocket.wsClosed() }.isSuccess()
-        expectCatching { webSocket.connectionClosed(1000, remote) }.isSuccess()
-        if (remote) expectCatching { webSocket.autoRestart() }.isSuccess()
+        verify { webSocket.connectionClosed(CloseFrame.NORMAL, true) }
+        verify { webSocket.autoRestart() }
+    }
+
+    @Test
+    fun `should auto-restart on abnormal local close (lost connection or pong timeout)`() {
+        client.onClose(CloseFrame.ABNORMAL_CLOSE, "no pong in time", false)
+
+        verify { webSocket.connectionClosed(CloseFrame.ABNORMAL_CLOSE, false) }
+        verify { webSocket.autoRestart() }
+    }
+
+    @Test
+    fun `should not auto-restart on deliberate local close`() {
+        client.onClose(CloseFrame.NORMAL, "closed by client", false)
+
+        verify { webSocket.connectionClosed(CloseFrame.NORMAL, false) }
+        verify(exactly = 0) { webSocket.autoRestart() }
     }
 }


### PR DESCRIPTION
## Problem

With `setAutoRestart(true)` the client fails to reconnect when the miniserver stops responding to websocket pings (a "frozen" connection). The connection stays dead until the application is restarted manually, even though auto-restart is enabled.

## Root cause

When the remote end stops answering pongs, the underlying Java-WebSocket `ConnectionLostChecker` closes the socket **locally** with code `1006` (`ABNORMAL_CLOSE`):

```
LoxoneWebsocketClient - Closed by local end because of 1006:
The connection was closed because the other endpoint did not respond with a pong in time.
```

In `LoxoneWebsocketClient.onClose()` the restart is gated behind `remote == true`:

```java
if (remote && code != CloseFrame.NEVER_CONNECTED) {
    ws.autoRestart();
}
```

A clean remote close (`1000`) recovers fine, but a `1006` **local** close — the most common real "frozen connection" case — never schedules a restart.

## Fix

Also restart on an abnormal local close (`1006`):

```java
if (code != CloseFrame.NEVER_CONNECTED && (remote || code == CloseFrame.ABNORMAL_CLOSE)) {
    ws.autoRestart();
}
```

A deliberate `LoxoneWebSocket.close()` goes through `closeBlocking()` and produces a `NORMAL` (`1000`) local close, so intentional shutdowns are still excluded and won't trigger a restart.

## Tests

`LoxoneWebsocketClientTest` now covers three cases:
- remote close → restart
- abnormal local close (1006) → restart
- deliberate local close (1000) → no restart